### PR TITLE
[bug fix] 'messages[0].content[1].image_url' should be object

### DIFF
--- a/background.js
+++ b/background.js
@@ -49,7 +49,9 @@ async function analyzeLocation(screenshot) {
                 },
                 {
                   type: "image_url",
-                  image_url: screenshot
+                  image_url: {
+                    url: screenshot
+                  }
                 }
               ]
             }


### PR DESCRIPTION
'messages[0].content[1].image_url' 需要是一个 object
否则会报错: 
错误: API请求失败: 400 - Invalid type for 'messages[0].content[1].image_url': expected an object, but got a string instead.